### PR TITLE
[#1] superstates-to-handle-events-unhandled-by-child-states

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,10 @@
 1. Implement transition actions
 1. More unit tests (specially for `StateManager` class)
 1. Add SFINAE for `StateManager`
-1. Implement `IState` class that will define an interface for states
 1. Currently, there are usages of raw pointers in the `State` classes, I believe that this could be improved
-1. Superstates to be able to handle events that are unhandled by child states
 1. Create another common level of abstraction that will define an "active object" object, which is composed of all the common components:
     - HSM, event queue, thread and common interface methods like `start`, `stop`, etc
+    - Dependency injection
 1. Improve "shutdown" of an object to properly stop it's thread
 1. Currently, there is no block-less way of sleeping an object.
     - Implement a centralized infrastructure for timers that might have it's own thread of execution and that can exchange events with the objects rather than having the objects call `std::this_thread::sleep_for()` within their own threads

--- a/samples/toaster/main.cpp
+++ b/samples/toaster/main.cpp
@@ -376,12 +376,12 @@ int Baking::process_event(IEvent_ptr event)
 int main(int argc, char** argv)
 {
     std::vector<IEvent_ptr> events;
-    events.emplace_back(std::make_shared<Evts::DoorOpen>()); // 0
-    events.emplace_back(std::make_shared<Evts::DoorClose>()); // 1
-    events.emplace_back(std::make_shared<Evts::DoToasting>()); // 2
-    events.emplace_back(std::make_shared<Evts::DoBaking>()); // 3
-    events.emplace_back(std::make_shared<Evts::Timeout>()); // 4
-    events.emplace_back(std::make_shared<Evts::Shutdown>()); // 5
+    events.emplace_back(std::make_shared<Evts::DoorOpen>());    // 0
+    events.emplace_back(std::make_shared<Evts::DoorClose>());   // 1
+    events.emplace_back(std::make_shared<Evts::DoToasting>());  // 2
+    events.emplace_back(std::make_shared<Evts::DoBaking>());    // 3
+    events.emplace_back(std::make_shared<Evts::Timeout>());     // 4
+    events.emplace_back(std::make_shared<Evts::Shutdown>());    // 5
 
     std::shared_ptr<Toaster::Toaster> tst = std::make_shared<Toaster::Toaster>();
     // tst->connect_callbacks();


### PR DESCRIPTION
- [#1] Change 'processEvent' method to be able to iterate over parent states when event is not handled in current state